### PR TITLE
Generale fixes en toevoeging aan de install script voor unix

### DIFF
--- a/install/unix.sh
+++ b/install/unix.sh
@@ -25,6 +25,9 @@ install_mongodb() {
                 sudo apt update && sudo apt install -y mongodb
             elif command dnf --version &> /dev/null; then
                 sudo dnf install -y mongodb
+            elif command yay --version &> /dev/null; then
+            #ik kan geen manier vinden om het te automatiseren. Dus als jij het weet stop het er in!
+                yay -S aur/mongodb-bin
             else
                 echo "❌ Geen compatibele package manager gevonden!"
                 exit 1
@@ -65,6 +68,9 @@ install_node() {
                 sudo dnf install -y nodejs
                 elif command brew -v &> /dev/null; then
                     brew install node
+                elif command yay --version &> /dev/null; then
+                #ik kan geen manier vinden om het te automatiseren. Dus als jij het weet stop het er in!
+                    yay -S extra/nodejs
             else
                 echo "❌ Geen compatibele package manager gevonden!"            
                 exit 1

--- a/install/unix.sh
+++ b/install/unix.sh
@@ -149,7 +149,7 @@ use $DB_NAME;
 db.test_collection.insertOne({ created: new Date() });
 "  > /dev/null 2>&1
 echo "✅ db aangemaakt"
-
+echo "🚀 Starten met install van node packages (Dit kan heel lang duren)"
 # Verberg npm logs
 npm i --legacy-peer-deps > /dev/null 2>&1
 

--- a/install/unix.sh
+++ b/install/unix.sh
@@ -19,19 +19,32 @@ install_mongodb() {
     fi
 
     echo "🚀 MongoDB installeren..."
-    if [ "$OS_TYPE" == "macOS" ]; then
-        brew tap mongodb/brew
-        brew install mongodb-community@8.0
-    elif [ "$OS_TYPE" == "Linux" ]; then
-        if command -v apt &> /dev/null; then
-            sudo apt update && sudo apt install -y mongodb
-        elif command -v dnf &> /dev/null; then
-            sudo dnf install -y mongodb
-        else
-            echo "❌ Geen compatibele package manager gevonden!"
-            exit 1
-        fi
-    fi
+    case "$OSTYPE" in
+    "linux"* )
+        if command apt -v &> /dev/null; then
+                sudo apt update && sudo apt install -y mongodb
+            elif command dnf --version &> /dev/null; then
+                sudo dnf install -y mongodb
+            elif command brew -v &> /dev/null; then
+                brew tap mongodb/brew
+                brew install mongodb-community@8.0
+            else
+                echo "❌ Geen compatibele package manager gevonden!"
+                exit 1
+        fi ;;
+
+    "darwin"* )
+        #macos. niet zeker of ook moderne versies darwin zijn maar ik heb geen manier om te checken
+        if command brew -v &> /dev/null; then
+                brew tap mongodb/brew
+                brew install mongodb-community@8.0
+            else
+                echo "❌ Geen compatibele package manager gevonden!"
+                exit 1
+        fi ;;
+    * )
+        echo '❌ Geen compatibele os gevonden!'
+esac
 
     if ! command -v mongod &> /dev/null; then
         echo "❌ MongoDB installatie is mislukt!"
@@ -47,19 +60,29 @@ install_node() {
     fi
 
     echo "🚀 Node.js installeren..."
-    if [ "$OS_TYPE" == "macOS" ]; then
-        brew install node
-    elif [ "$OS_TYPE" == "Linux" ]; then
-        if command -v apt &> /dev/null; then
-            sudo apt update && sudo apt install -y nodejs
-        elif command -v dnf &> /dev/null; then
-            sudo dnf install -y nodejs
-        else
+    case "$OSTYPE" in
+    "linux"* )
+            if command -v apt &> /dev/null; then
+                sudo apt update && sudo apt install -y nodejs
+            elif command -v dnf &> /dev/null; then
+                sudo dnf install -y nodejs
+                elif command brew -v &> /dev/null; then
+                    brew install node
+            else
+                echo "❌ Geen compatibele package manager gevonden!"            
+                exit 1
+        fi ;;
+    "darwin"* )
+        #macos. niet zeker of ook moderne versies darwin zijn maar ik heb geen manier om te checken
+        if command brew -v &> /dev/null; then
+                brew install node
+            else 
             echo "❌ Geen compatibele package manager gevonden!"            
-            exit 1
-        fi
-    fi
-
+                exit 1
+        fi ;;
+    * )
+        echo '❌ OS type niet gevonden.'
+esac
     if ! command -v node &> /dev/null; then
         echo "❌ Node.js installatie is mislukt!"
         exit 1

--- a/install/unix.sh
+++ b/install/unix.sh
@@ -25,9 +25,6 @@ install_mongodb() {
                 sudo apt update && sudo apt install -y mongodb
             elif command dnf --version &> /dev/null; then
                 sudo dnf install -y mongodb
-            elif command brew -v &> /dev/null; then
-                brew tap mongodb/brew
-                brew install mongodb-community@8.0
             else
                 echo "❌ Geen compatibele package manager gevonden!"
                 exit 1


### PR DESCRIPTION
twee commits waren op de verkeerde branch:
hier zijn die commit messages:

(https://github.com/polarnl/PolarLearn/commit/fcbec6c8885f979578afa9bf3e285c29512eba3f)
Fix detectie van het os type

(https://github.com/polarnl/PolarLearn/commit/77ad924135ef283030cec0a422f968b2ef90baf9)
check dat brew is ge instaleerd en voeg support toe voor brew op linux

laten we eerlijk zijn dit word verscheinlijk binnenkort herplaatst met de docker maar heb dit scriptje maar laten werken.

Ik heb de detectie van het os type gefixst door een case te gebruiken met de bash variable $OSTYPE.

Ik heb toegevoegd:

1. Een check om te zien of de gebruiker brew heeft.
2. Linuxbrew support voor node (mongo lijkt alleen te werken op macos).
3. Heb support toegevoegd voor yay